### PR TITLE
Add Firefox for Android to install.rdf

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -8,10 +8,19 @@
         <em:bootstrap>true</em:bootstrap>
         <em:creator>Simon Lindholm</em:creator>
         <em:optionsType>2</em:optionsType>
+        <!-- Firefox for Desktop -->
         <em:targetApplication>
             <Description>
                 <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
                 <em:minVersion>15.0</em:minVersion>
+                <em:maxVersion>29.0a1</em:maxVersion>
+            </Description>
+        </em:targetApplication>
+        <!-- Firefox for Android -->
+        <em:targetApplication>
+            <Description>
+                <em:id>{aa3c5121-dab2-40e2-81ca-7ea25febc110}</em:id>
+                <em:minVersion>26.0.1</em:minVersion>
                 <em:maxVersion>29.0a1</em:maxVersion>
             </Description>
         </em:targetApplication>


### PR DESCRIPTION
This commits marks the addon as being compatible with Firefox for Android. I have set the minimum version to 26.0.1 as that is the lowest version I have tested the addon with.
